### PR TITLE
chore: Use status.remmal.net as the domain

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -8,8 +8,7 @@ sites:
     url: https://status.remmal.net
 
 status-website:
-  cname: hamzaremmal.github.io
-  baseUrl: /status.remmal.net
+  cname: status.remmal.net
   logoUrl: https://raw.githubusercontent.com/upptime/upptime.js.org/master/static/img/icon.svg
   name: Status | remmal.net
   introTitle: "**Upptime** is the open-source uptime monitor and status page, powered entirely by GitHub."


### PR DESCRIPTION
Closes #1 